### PR TITLE
Correct MetSim line 51

### DIFF
--- a/R/metSim.R
+++ b/R/metSim.R
@@ -48,7 +48,7 @@ metSim <- function(dw_model, newdata, metVars = c("ws", "wd", "temp"),
   names(prediction)[2] <- pollutant
 
   ## Aggregate results
-  dplyr::group_by(prediction, .data$date) %>%
+  prediction <- dplyr::group_by(prediction, .data$date) %>%
     dplyr::summarise({{ pollutant }} := mean(.data[[pollutant]]))
 
   return(dplyr::tibble(prediction))


### PR DESCRIPTION
Hello :)

I hope creating a pull request is okay - this is my first time doing so, so hopefully I have done everything correctly!

I took a further look into issue #6 and I think I have resolved it. I don't believe it to have been a date issue at all, but instead a case of some missing syntax.

Using the latest commit to the main branch to detrend a dataframe with 59,138, the MetSim output is a dataframe with 11,827,600. I have left B as 200, and you'll note that 59,138 * 200 = 11,827,600...

![image](https://user-images.githubusercontent.com/115170687/236212563-5d573c2c-2023-4fc9-896a-809d49aa8696.png)

However, using the MetSim function within this fork returns a dataframe with 59,138 columns

![image](https://user-images.githubusercontent.com/115170687/236212683-a657e6d7-37cc-4529-9b97-5e5bf38114a9.png)

I'm not a developer by any means, so happy for you to make any changes to match the package style or anything else :)
