### PR TITLE
Name output lists in `plotAllPD()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,5 +33,5 @@ License: GPL (>= 2)
 Encoding: UTF-8
 LazyLoad: yes
 LazyData: yes
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)

--- a/R/partialDep.R
+++ b/R/partialDep.R
@@ -233,7 +233,7 @@ plotPD <- function(dat, variable, ylim = NULL, plotit = TRUE,
 #'
 #' @param dw_model Model object from running \code{buildMod}.
 #' @param ylim y-axis label. Will default to pollutant name.
-#' @param nrow Number of rows for th eplots.
+#' @param nrow Number of rows for the plots.
 #' @param ... extra plotting arguments.
 #' @export
 #' @return A plot
@@ -256,9 +256,15 @@ plotAllPD <- function(dw_model, ylim = NULL, nrow = NULL, ...) {
   # extract first element of list, which is the plot
   thedata <- sapply(plots, "[", 2)
   plots <- sapply(plots, "[", 1)
-
+  
+  # plot all outputs
   do.call(gridExtra::grid.arrange, c(plots, nrow = nrow))
-
+  
+  # name plots & data for easy indexing
+  names(thedata) <- influ$var
+  names(plots) <- influ$var
+  
+  # invisibly return list
   invisible(list(plot = plots, data = thedata))
 }
 

--- a/man/plotAllPD.Rd
+++ b/man/plotAllPD.Rd
@@ -11,7 +11,7 @@ plotAllPD(dw_model, ylim = NULL, nrow = NULL, ...)
 
 \item{ylim}{y-axis label. Will default to pollutant name.}
 
-\item{nrow}{Number of rows for th eplots.}
+\item{nrow}{Number of rows for the plots.}
 
 \item{...}{extra plotting arguments.}
 }


### PR DESCRIPTION
This PR names the lists in the returned object from `plotAllPD()`. This makes them easier to index later.

``` r
devtools::load_all()
#> ℹ Loading deweather

# build mod
mod <-
  buildMod(
    openair::selectByDate(openair::mydata, year = 2005),
    vars = c("trend", "ws", "wd", "hour", "weekday"),
    pollutant = "nox",
    n.core = 6
  )

# get all pd
png(tempfile())
pd <- plotAllPD(mod)
dev.off()
#> png 
#>   2

# see new names
names(pd)
#> [1] "plot" "data"
names(pd$plot)
#> [1] "wd"      "hour"    "weekday" "trend"   "ws"
names(pd$data)
#> [1] "wd"      "hour"    "weekday" "trend"   "ws"

# can easily index 
patchwork::wrap_plots(pd$plot[c("wd", "ws")])
```

![](https://i.imgur.com/eoVQ0TP.png)<!-- -->

<sup>Created on 2023-06-07 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
