### PR TITLE
Corrections to testMod()

### DIFF
--- a/R/testMod.R
+++ b/R/testMod.R
@@ -206,8 +206,8 @@ testMod <- function(input_data,
   
   stats_both <-
     dplyr::left_join(
-      dplyr::rename(stats_train, "train" = .data$value),
-      dplyr::rename(stats, "test" = .data$value),
+      dplyr::rename(stats_train, "train" = "value"),
+      dplyr::rename(stats, "test" = "value"),
       by = "statistic"
     ) %>%
     dplyr::tibble()

--- a/R/testMod.R
+++ b/R/testMod.R
@@ -78,17 +78,17 @@ testMod <- function(input_data,
     # if n.trees = NA, calculate optimum number using CV; use all data for this
     # because it will be randomly split select maximum of 10000 rows
     if (nrow(train.dat) > 10000) {
-      data_for_CV <- train.dat %>%
+      train.dat <- train.dat %>%
         dplyr::slice_sample(n = 10000)
     } else {
-      data_for_CV <- train.dat
+      train.dat <- train.dat
     }
     
     CV_mod <- 
       gbm::gbm(
         eq,
         distribution = "gaussian",
-        data = data_for_CV,
+        data = train.dat,
         n.trees = 5000,
         shrinkage = shrinkage,
         interaction.depth = interaction.depth,
@@ -106,7 +106,7 @@ testMod <- function(input_data,
       gbm::gbm(
         eq,
         distribution = "gaussian",
-        data = data_for_CV,
+        data = train.dat,
         n.trees = n.trees,
         shrinkage = shrinkage,
         interaction.depth = interaction.depth,
@@ -127,7 +127,7 @@ testMod <- function(input_data,
   pred_train <-
     gbm::predict.gbm(
       CV_mod,
-      newdata = data_for_CV,
+      newdata = train.dat,
       n.trees = n.trees,
       shrinkage = shrinkage,
       interaction.depth = interaction.depth,
@@ -136,7 +136,7 @@ testMod <- function(input_data,
       seed = seed
     )
   
-  pred_train <- tibble(data_for_CV, pred = pred_train)
+  pred_train <- tibble(train.dat, pred = pred_train)
   
   ## calculate key model statistics
   stats_train <-

--- a/R/testMod.R
+++ b/R/testMod.R
@@ -84,7 +84,7 @@ testMod <- function(input_data,
       train.dat <- train.dat
     }
     
-    CV_mod <- 
+    mod <- 
       gbm::gbm(
         eq,
         distribution = "gaussian",
@@ -99,7 +99,7 @@ testMod <- function(input_data,
       )  
     
     # find index for n trees with minimum CV error
-    min_MSE <- which.min(CV_mod$cv.error)
+    min_MSE <- which.min(mod$cv.error)
     
   } else {
     mod <- 
@@ -120,13 +120,13 @@ testMod <- function(input_data,
   if (is.na(n.trees)) {
     n.trees <- min_MSE
     cli::cli_inform(c("i" = "Optimum number of trees is {.strong {n.trees}}"))
-    cli::cli_inform(c("i" = "RMSE from cross-validation is {.strong {round(sqrt(CV_mod$cv.error[min_MSE]), 2)}}"))
+    cli::cli_inform(c("i" = "RMSE from cross-validation is {.strong {round(sqrt(mod$cv.error[min_MSE]), 2)}}"))
   }
   
   # predictions based on training data
   pred_train <-
     gbm::predict.gbm(
-      CV_mod,
+      mod,
       newdata = train.dat,
       n.trees = n.trees,
       shrinkage = shrinkage,
@@ -153,7 +153,7 @@ testMod <- function(input_data,
   
   pred <-
     gbm::predict.gbm(
-      CV_mod,
+      mod,
       newdata = pred.dat,
       n.trees = n.trees,
       shrinkage = shrinkage,

--- a/R/testMod.R
+++ b/R/testMod.R
@@ -136,7 +136,7 @@ testMod <- function(input_data,
       seed = seed
     )
   
-  pred_train <- tibble(train.dat, pred = pred_train)
+  pred_train <- dplyr::tibble(train.dat, pred = pred_train)
   
   ## calculate key model statistics
   stats_train <-

--- a/R/testMod.R
+++ b/R/testMod.R
@@ -101,6 +101,20 @@ testMod <- function(input_data,
     # find index for n trees with minimum CV error
     min_MSE <- which.min(CV_mod$cv.error)
     
+  } else {
+    mod <- 
+      gbm::gbm(
+        eq,
+        distribution = "gaussian",
+        data = data_for_CV,
+        n.trees = n.trees,
+        shrinkage = shrinkage,
+        interaction.depth = interaction.depth,
+        bag.fraction = bag.fraction,
+        n.minobsinnode = n.minobsinnode,
+        cv.folds = cv.folds,
+        verbose = FALSE
+      ) 
   }
   
   if (is.na(n.trees)) {


### PR DESCRIPTION
Hi!

I noticed an issue with `testMod()` today. I've rectified and made this pull request, which I hope is okay. :)

When `n.trees` was specified, the function returned an error:

```
mydata <- openair::mydata
deweather::testMod(data, 
vars = c("trend", "ws", "wd", "hour", "weekday", "week", "month"), 
pollutant = "no2", n.trees = 10)
Error in deweather::testMod(data, vars = c("trend", "ws", "wd", "hour",  : 
  object 'CV_mod' not found
```

However, if `n.trees` was omitted, `testMod()` worked as expected:

```
deweather::testMod(data, 
vars = c("trend", "ws", "wd", "hour", "weekday", "week", "month"),
pollutant = "no2")
ℹ Optimum number of trees is 1449
ℹ RMSE from cross-validation is 12.61
ℹ Percent increase in RMSE using test data is 21.1%
```

No model was being generated if `n.trees` was specified, which led to the error. I added an `else{}` into the function which ensures a model is still generated if `n.trees` is given. I also renamed `CV_mod` to `mod`, which allows the rest of the function to work regardless of which model was generated. This also meant renaming `data_for_CV` to `train.dat`.

Also, whilst I had the code open I corrected a couple of `tidyverse` related things, as there was a warning about deprecated syntax for `tidyselect` and `dplyr::` was missing from the `tibble` call.

(note: I wouldn't normally use `n.trees = 10`, but it runs faster for this example!)