### PR TITLE
fix: restore `intervals` arg to `plotPD()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,8 +40,6 @@ Imports:
 Suggests: 
     knitr,
     rmarkdown
-VignetteBuilder: 
-    knitr
 Encoding: UTF-8
 Language: en-GB
 LazyData: yes

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 * Fixed a bug where `plotPD()` would work differently if the input to `buildMod()` was a `data.frame` rather than a `tibble`.
 
+* `intervals` is now once again correctly used in `plotPD()`.
+
 # deweather 0.7.2
 
 ## Breaking changes

--- a/R/plotPD.R
+++ b/R/plotPD.R
@@ -131,6 +131,22 @@ plot_pd_helper <- function(dw_model,
   }
   dat$character <- dat$numeric <- NULL
   dat <- tidyr::unnest(dat, .data$data)
+  
+  # if data is numeric & not 'trend', apply intervals
+  if (is.numeric(dat$x) & variable != "trend") {
+    dat$x <- as.numeric(dat$x)
+    gap <- prettyGap(dat$x, intervals)
+    dat$x <- round_any(dat$x, gap)
+  }
+  
+  # summarise by interval 
+  dat <- dplyr::group_by(dat, .data$var, .data$x) %>%
+    dplyr::summarise(
+      mean = mean(.data$mean),
+      lower = min(.data$lower),
+      upper = max(.data$upper)
+    ) %>%
+    dplyr::ungroup()
 
   # get ylim range if needed
   if (is.null(ylim)) ylim <- rng(dat)


### PR DESCRIPTION
Should fix #19 

@davidcarslaw - can you confirm this is doing what you expect?

I'm not clear on the original purpose of `intervals` - is it just to smooth over the PD plots? Just copied over the code from a previous version pre-refactor.

Cheers!