### PR TITLE
Updates for changes to `mirai_map()` in mirai 1.3.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: deweather
 Title: Remove the influence of weather on air quality data
-Version: 0.7.2.9102
+Version: 0.7.2.9103
 Authors@R: 
     person("David", "Carslaw", , "david.carslaw@york.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0991-950X"))
@@ -25,7 +25,7 @@ Imports:
     lubridate,
     magrittr,
     mgcv,
-    mirai,
+    mirai (>= 1.3.0),
     openair,
     patchwork,
     purrr,

--- a/R/buildMod.R
+++ b/R/buildMod.R
@@ -110,7 +110,8 @@ buildMod <- function(input_data,
       bag.fraction = bag.fraction,
       n.minobsinnode = n.minobsinnode,
       cv.folds = cv.folds,
-      seed
+      seed,
+      n.cores = NULL
     )
   }
 
@@ -194,7 +195,8 @@ runGbm <-
            bag.fraction = bag.fraction,
            n.minobsinnode = n.minobsinnode,
            cv.folds = cv.folds,
-           seed = seed) {
+           seed = seed,
+           n.cores) {
     ## sub-sample the data for bootstrapping
     if (simulate) {
       dat <- dat[sample(nrow(dat), nrow(dat), replace = TRUE), ]
@@ -220,7 +222,8 @@ runGbm <-
       n.minobsinnode = n.minobsinnode,
       cv.folds = cv.folds,
       keep.data = TRUE,
-      verbose = FALSE
+      verbose = FALSE,
+      n.cores = n.cores
     )
 
     ## extract partial dependence components
@@ -280,7 +283,8 @@ partialDep <-
         bag.fraction = bag.fraction,
         n.minobsinnode = n.minobsinnode,
         cv.folds = cv.folds,
-        seed
+        seed,
+        n.cores = NULL
       )
     } else {
       pred <-
@@ -301,7 +305,8 @@ partialDep <-
                  interaction.depth = interaction.depth,
                  bag.fraction = bag.fraction,
                  n.minobsinnode = n.minobsinnode,
-                 cv.folds = cv.folds
+                 cv.folds = cv.folds,
+                 n.cores = 1L
                )
              )[.stop, if (progress) .progress])
     }

--- a/R/buildMod.R
+++ b/R/buildMod.R
@@ -283,11 +283,6 @@ partialDep <-
         seed
       )
     } else {
-      if (progress) {
-        ex <- c(mirai::.stop, mirai::.progress)
-      } else {
-        ex <- c(mirai::.stop)
-      }
       pred <-
         with(mirai::daemons(n.core),
              mirai::mirai_map(
@@ -308,7 +303,7 @@ partialDep <-
                  n.minobsinnode = n.minobsinnode,
                  cv.folds = cv.folds
                )
-             )[ex])
+             )[.stop, if (progress) .progress])
     }
 
     # partial dependence plots

--- a/R/metSim.R
+++ b/R/metSim.R
@@ -39,12 +39,6 @@ metSim <-
       newdata <- prepData(newdata)
     }
     
-    if (progress) {
-      ex <- c(mirai::.stop, mirai::.progress)
-    } else {
-      ex <- c(mirai::.stop)
-    }
-    
     prediction <-
       with(
         mirai::daemons(n.core),
@@ -58,7 +52,7 @@ metSim <-
             mod = mod,
             metVars = metVars
           )
-        )[ex]
+        )[.stop, if (progress) .progress]
       ) %>%
       purrr::list_rbind()
     


### PR DESCRIPTION
The syntax for the map options has been simplified.

I'm providing this PR as mirai 1.3.0 has just been updated on CRAN with this breaking change. Thanks.